### PR TITLE
Update Traefik to include a host without the www.

### DIFF
--- a/deploy/docker-compose.prod.yaml
+++ b/deploy/docker-compose.prod.yaml
@@ -34,7 +34,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.client.entrypoints=websecure"
-      - "traefik.http.routers.client.rule=Host(`www.evanbecker.net`)"
+      - "traefik.http.routers.client.rule=Host(`www.evanbecker.net`) || Host(`evanbecker.net`)"
       - "traefik.http.middlewares.client-web-secure.redirectscheme.scheme=https"
       - "traefik.http.routers.client.middlewares=redirect-non-www-to-www,client-web-secure"
       - "traefik.http.middlewares.redirect-non-www-to-www.redirectregex.permanent=true"


### PR DESCRIPTION
## Changes
- Update Traefik to include `Host(`evanbecker.net`)`, so that it can properly bind when a user types in the address _without_ `www.*`