### PR TITLE
Drop visible backticks on inline code, dedupe ray-marching embeds

### DIFF
--- a/evanbecker-client/content/articles/ray-marching-with-claude.md
+++ b/evanbecker-client/content/articles/ray-marching-with-claude.md
@@ -79,9 +79,6 @@ That single line tiles the entire scene infinitely. The SDF evaluates as if ther
 
 This is where ray marching stops being "a way to draw spheres" and becomes a way to think about geometry. You can describe shapes that would be impossible to mesh: infinite tilings, fractal structures, twisted columns, surfaces displaced by procedural noise. The Sierpinski tetrahedron in the [Unity version](https://github.com/evanjbecker/Raymarch) is recursive: a function that calls itself a fixed number of times, applying scale and folding operations until each layer subdivides into the next.
 
-::ray-march-embed{preset="Vortex" height="h-[400px]"}
-::
-
 The big realization, the one that took a while to land: SDFs are a *language for describing geometry*. The fact that you can render them is downstream of the fact that the math itself is exact. There are no approximations until the very end, when you sample the field. The shape exists with infinite precision until the moment you look at it.
 
 ## The Port

--- a/evanbecker-client/tailwind.config.ts
+++ b/evanbecker-client/tailwind.config.ts
@@ -47,6 +47,12 @@ export default {
                 textDecorationColor: '#2D95FC',
               },
             },
+            // The typography plugin's default styling renders visible backticks
+            // around inline <code> via ::before/::after pseudo-elements. We want
+            // inline code to be styled (monospace, color) but NOT decorated with
+            // literal backtick characters in the rendered output.
+            'code::before': { content: 'none' },
+            'code::after': { content: 'none' },
           },
         },
         invert: {


### PR DESCRIPTION
## Summary

Two small article-rendering fixes for prod.

- **Inline code: drop visible backtick decoration.** Tailwind Typography defaults to wrapping inline `<code>` with literal backtick characters via `::before`/`::after` pseudo-elements. The markdown source intentionally uses inline code for things like `r`, `min`, `smin`, `mod`, `useApi.tsx` — we want those styled as inline code (monospace + color) but not visually decorated with backtick characters. Override `content: 'none'` on `code::before`/`::after` in the prose typography config. Affects article body and the privacy policy.
- **Article: remove duplicate ray marcher.** The "Math Pretending to Be Architecture" article was embedding two `::ray-march-embed` instances (Deep Sea hero + Vortex mid-article). Kept the hero, removed the Vortex. The sandbox link at the article's end still exposes every preset interactively.

## Test plan

- [ ] Article body renders inline code without surrounding backtick characters
- [ ] Privacy policy's `localStorage` mention renders without backticks
- [ ] Ray-marching article shows exactly one ray marcher embed
- [ ] Sandbox link at the bottom of the ray-marching article still works