### PR TITLE
Add Sandbox link to header nav

### DIFF
--- a/evanbecker-client/components/AppHeader.vue
+++ b/evanbecker-client/components/AppHeader.vue
@@ -155,6 +155,7 @@ const navLinks = [
   { href: '/about-me', label: 'About Me' },
   { href: '/contact', label: 'Contact' },
   { href: '/articles', label: 'Blog' },
+  { href: '/sandbox', label: 'Sandbox' },
 ]
 </script>
 


### PR DESCRIPTION
## Summary
- Single-line addition to `navLinks` in [AppHeader.vue](evanbecker-client/components/AppHeader.vue) — Sandbox now appears in both desktop and mobile nav.
- Pages were live but unreachable from the UI before this.
- The Sandbox pages are still `noindex`, so this affects only human navigation, not crawler indexing.

## Test plan
- [ ] After merge, `https://test.evanbecker.net/` shows a "Sandbox" link in the top nav
- [ ] Clicking it lands on `/sandbox`
- [ ] Mobile menu (hamburger) also shows the link