### PR TITLE
Auth recovery flow + The Wall publish date

### DIFF
--- a/evanbecker-client/composables/useApi.ts
+++ b/evanbecker-client/composables/useApi.ts
@@ -9,8 +9,29 @@ export function useApi() {
   // is entirely eliminated there; on the client it runs in component setup context.
   let getTokenFn: (() => Promise<string>) | null = null
   if (import.meta.client) {
-    const { getAccessTokenSilently } = useAuth0()
-    getTokenFn = getAccessTokenSilently
+    const { getAccessTokenSilently, loginWithRedirect } = useAuth0()
+    getTokenFn = async () => {
+      try {
+        return await getAccessTokenSilently()
+      } catch (e: any) {
+        // The local refresh token is gone, expired, or has been rotation-revoked.
+        // The Auth0 tenant SSO session cookie typically lives longer than the
+        // refresh token, so try a silent round-trip with prompt=none to recover
+        // transparently. If the SSO session is alive the user comes back
+        // re-authenticated without seeing a sign-in screen. If it's also dead,
+        // Auth0 redirects back with an error and this throw propagates so the
+        // caller can show "sign in again". appState.target preserves the user's
+        // location for a future onRedirectCallback to consume.
+        const recoverable = ['login_required', 'consent_required', 'missing_refresh_token', 'invalid_grant']
+        if (recoverable.includes(e?.error)) {
+          await loginWithRedirect({
+            authorizationParams: { prompt: 'none' },
+            appState: { target: window.location.pathname + window.location.search },
+          })
+        }
+        throw e
+      }
+    }
   }
 
   async function fetchWithAuth(path: string, options: RequestInit = {}) {

--- a/evanbecker-client/composables/useApi.ts
+++ b/evanbecker-client/composables/useApi.ts
@@ -24,9 +24,17 @@ export function useApi() {
         // location for a future onRedirectCallback to consume.
         const recoverable = ['login_required', 'consent_required', 'missing_refresh_token', 'invalid_grant']
         if (recoverable.includes(e?.error)) {
+          const target = window.location.pathname + window.location.search
+          // sessionStorage is the recovery channel for the SSO-also-dead case.
+          // appState.target is what auth0-vue uses on success; sessionStorage is
+          // a backup the auth0 plugin reads in the failure path where auth0-vue
+          // would otherwise redirect to errorPath || '/' and lose the location.
+          if (typeof sessionStorage !== 'undefined') {
+            sessionStorage.setItem('auth0_recovery_target', target)
+          }
           await loginWithRedirect({
             authorizationParams: { prompt: 'none' },
-            appState: { target: window.location.pathname + window.location.search },
+            appState: { target },
           })
         }
         throw e

--- a/evanbecker-client/content/articles/the-wall.md
+++ b/evanbecker-client/content/articles/the-wall.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Wall'
 description: 'AI engineering keeps running into a boundary that science itself was built to ignore. Where the wall came from, who has hit it before, and what working honestly on the wrong side of it looks like.'
-date: '2026-04-25'
+date: '2026-04-27'
 tags:
   - software
   - ai

--- a/evanbecker-client/plugins/auth0.client.ts
+++ b/evanbecker-client/plugins/auth0.client.ts
@@ -22,6 +22,30 @@ export default defineNuxtPlugin((nuxtApp) => {
     })
 
     nuxtApp.vueApp.use(auth0)
+
+    // Recovery: useApi.fetchWithAuth triggers a prompt=none redirect when the
+    // local refresh token is dead. On success, auth0-vue navigates to the
+    // appState.target. On failure (SSO session also dead), it falls back to
+    // errorPath || '/', which loses the user's place. sessionStorage carries
+    // the intended target across the round-trip so we can restore it here
+    // regardless of which branch auth0-vue takes.
+    if (typeof sessionStorage !== 'undefined') {
+      const target = sessionStorage.getItem('auth0_recovery_target')
+      if (target) {
+        sessionStorage.removeItem('auth0_recovery_target')
+        // Wait for auth0-vue's __checkSession to finish before checking where
+        // we actually landed, otherwise we race its router.push.
+        const stop = watch(auth0.isLoading, (loading: boolean) => {
+          if (!loading) {
+            stop()
+            const currentPath = window.location.pathname + window.location.search
+            if (currentPath !== target) {
+              navigateTo(target)
+            }
+          }
+        }, { immediate: true })
+      }
+    }
   } catch (e) {
     console.warn('Auth0: failed to initialize, app will run without authentication.', e)
   }


### PR DESCRIPTION
## Summary

- **Silent re-auth recovery** — When the local refresh token is dead (expired, rotation-revoked, missing from cache, or rejected by Auth0), `useApi.fetchWithAuth` now triggers a `prompt=none` round-trip via `loginWithRedirect`. If the Auth0 SSO session cookie is still alive the user is transparently re-authenticated. If it's also dead, the user lands back on the page they were trying to use with the existing Sign-In UI surfaced.
- **Location preservation through the SSO-dead branch** — auth0-vue falls back to `errorPath || '/'` when `handleRedirectCallback` throws, which would otherwise drop the user on the homepage. `useApi` now writes the intended target into `sessionStorage` before redirect, and the auth0 plugin reads it after `__checkSession` settles to navigate the user back. Net effect for `/account`: silent recovery on SSO-alive, visible Sign-In on `/account` itself when SSO is dead. Login prompts only appear on `/account`, never site-wide.
- **The Wall publish date** — bumped frontmatter from `2026-04-25` to `2026-04-27` to match the actual prod publish date.

## Test plan

- [ ] Sign in normally on `/account` — profile loads, no behavioral change
- [ ] Force a stale token (e.g., revoke the refresh token in Auth0 dashboard or wait past the rotation window) and visit `/account`
  - [ ] If SSO cookie alive: page lands on `/account` authenticated, profile loads, no Sign-In screen
  - [ ] If SSO cookie also dead: page lands on `/account` with the "Sign in to manage your account" UI and the Sign In button
- [ ] Sign-Out → click Sign In on header → confirm normal interactive login still works (no redirect to `/account`)
- [ ] Browse public pages (`/`, `/articles`, `/articles/why-1196-isnt-agi`) with a dead refresh token — no forced redirects to Auth0
- [ ] `/articles/the-wall` shows publish date "April 27, 2026"