### PR TITLE
Fix article date timezone shift, correct The Wall publish date

### DIFF
--- a/evanbecker-client/content/articles/the-wall.md
+++ b/evanbecker-client/content/articles/the-wall.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Wall'
 description: 'AI engineering keeps running into a boundary that science itself was built to ignore. Where the wall came from, who has hit it before, and what working honestly on the wrong side of it looks like.'
-date: '2026-04-27'
+date: '2026-04-25'
 tags:
   - software
   - ai

--- a/evanbecker-client/content/articles/the-wall.md
+++ b/evanbecker-client/content/articles/the-wall.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Wall'
 description: 'AI engineering keeps running into a boundary that science itself was built to ignore. Where the wall came from, who has hit it before, and what working honestly on the wrong side of it looks like.'
-date: '2026-04-25'
+date: '2026-04-24'
 tags:
   - software
   - ai

--- a/evanbecker-client/pages/articles/[...slug].vue
+++ b/evanbecker-client/pages/articles/[...slug].vue
@@ -56,7 +56,7 @@ useSeoMeta({
         :datetime="article.date"
         class="text-sm font-medium text-slate-400 dark:text-slate-500"
       >
-        {{ new Date(article.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }) }}
+        {{ formatArticleDate(article.date) }}
       </time>
       <h1 class="mt-2 font-serif text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl dark:text-slate-50">
         {{ article.title }}

--- a/evanbecker-client/pages/articles/index.vue
+++ b/evanbecker-client/pages/articles/index.vue
@@ -30,7 +30,7 @@ useSeoMeta({
             :datetime="article.date"
             class="text-sm font-medium text-slate-400 dark:text-slate-500"
           >
-            {{ new Date(article.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }) }}
+            {{ formatArticleDate(article.date) }}
           </time>
 
           <h2 class="mt-2 text-xl font-semibold text-slate-800 dark:text-slate-100">

--- a/evanbecker-client/pages/index.vue
+++ b/evanbecker-client/pages/index.vue
@@ -113,7 +113,7 @@ const articleCount = computed(() => articles.value?.length ?? 0)
               :datetime="article.date"
               class="text-xs font-medium text-slate-500 dark:text-slate-500"
             >
-              {{ new Date(article.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }) }}
+              {{ formatArticleDate(article.date) }}
             </time>
             <h3 class="mt-2 text-lg font-semibold text-slate-800 group-hover:text-[#0C65E5] dark:text-slate-100 dark:group-hover:text-[#2D95FC]">
               <NuxtLink :to="article._path">{{ article.title }}</NuxtLink>

--- a/evanbecker-client/utils/formatDate.ts
+++ b/evanbecker-client/utils/formatDate.ts
@@ -1,0 +1,23 @@
+/**
+ * Format a YYYY-MM-DD article date string for display, treating it as a
+ * calendar date in the viewer's local timezone.
+ *
+ * The naive `new Date('2026-04-27').toLocaleDateString(...)` is the trap:
+ * the bare YYYY-MM-DD form is parsed by the spec as UTC midnight, which
+ * for any viewer west of UTC renders as the *previous* calendar day. The
+ * SSR pass uses the date as a string and looks correct, then the client
+ * hydration re-parses it through Date and shifts it back by one day. The
+ * "briefly shows the right date then jumps to the wrong one" symptom is
+ * the visible expression of that hydration mismatch.
+ *
+ * Appending `T00:00:00` (no Z) is parsed per spec as local time, so the
+ * Date object lands on the intended calendar day on both server and
+ * client regardless of timezone.
+ */
+export function formatArticleDate(dateStr: string): string {
+  return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}


### PR DESCRIPTION
## Summary

- **Timezone bug fix.** `new Date('2026-04-27').toLocaleDateString(...)` was parsing the bare YYYY-MM-DD as UTC midnight, which rendered as the previous calendar day for any viewer west of UTC. Symptom: dates briefly showed correctly on first paint, then shifted one day earlier after client hydration. Added `utils/formatArticleDate` (auto-imported) that appends `T00:00:00` (no Z) so the parse lands on the intended calendar day on both server and client. Applied to all three article-date renders (`/articles/[slug]`, `/articles`, `/`).
- **The Wall publish date.** Set to `2026-04-24` to match the actual Friday authoring date. The previous `2026-04-25` was already off-by-one and the timezone bug was accidentally compensating; with the formatter fix in place the frontmatter needed to reflect the real date directly.

## Test plan

- [ ] `/articles/the-wall` shows publish date "April 24, 2026" — no flicker
- [ ] `/articles/why-1196-isnt-agi` shows publish date "April 27, 2026" — no flicker
- [ ] `/articles` and `/` listings show the same dates as the article pages, no shift between SSR and hydrated render
- [ ] Spot-check from a non-UTC timezone if possible (US Central, etc.)