### PR TITLE
Hotfix: gate auth recovery behind opt-in to fix blog kickoff

### DIFF
--- a/evanbecker-client/composables/useApi.ts
+++ b/evanbecker-client/composables/useApi.ts
@@ -1,5 +1,21 @@
 import { useAuth0 } from '@auth0/auth0-vue'
 
+export interface FetchWithAuthOptions extends RequestInit {
+  /**
+   * Opt in to automatic silent re-auth when getAccessTokenSilently throws.
+   *
+   * Defaults to false, which is correct for almost every call site: a public
+   * blog page that quietly tries to load the current user (e.g. the comment
+   * section) must NOT trigger a redirect when the visitor is logged out, or
+   * any visitor reading a public article will be bounced to Auth0 mid-read.
+   *
+   * Pass `recover: true` only on call sites where (a) the user is on a page
+   * dedicated to authenticated functionality and (b) silently re-establishing
+   * a session is the right UX. The /account page mount is the canonical case.
+   */
+  recover?: boolean
+}
+
 export function useApi() {
   const config = useRuntimeConfig()
   const baseUrl = config.public.apiUrl?.replace(/\/$/, '') || ''
@@ -8,53 +24,56 @@ export function useApi() {
   // import.meta.client is statically false in the server bundle so this block
   // is entirely eliminated there; on the client it runs in component setup context.
   let getTokenFn: (() => Promise<string>) | null = null
+  let attemptRecovery: (() => Promise<void>) | null = null
   if (import.meta.client) {
-    const { getAccessTokenSilently, loginWithRedirect } = useAuth0()
-    getTokenFn = async () => {
+    const { getAccessTokenSilently, loginWithRedirect, isAuthenticated } = useAuth0()
+    getTokenFn = getAccessTokenSilently
+    attemptRecovery = async () => {
+      // Belt-and-suspenders: if the user has no Auth0 session at all (never
+      // logged in, or explicitly logged out), there's nothing to recover and
+      // bouncing them through Auth0 would be disruptive. Skip silently.
+      if (!isAuthenticated.value) return
+      // The local refresh token is gone, expired, or rotation-revoked but the
+      // Auth0 tenant SSO session cookie may still be alive. Try a silent
+      // round-trip with prompt=none. On success the user comes back
+      // re-authenticated. On failure Auth0 redirects back with an error and
+      // the auth0 plugin's recovery target watcher restores their location.
+      const target = window.location.pathname + window.location.search
+      if (typeof sessionStorage !== 'undefined') {
+        sessionStorage.setItem('auth0_recovery_target', target)
+      }
+      await loginWithRedirect({
+        authorizationParams: { prompt: 'none' },
+        appState: { target },
+      })
+    }
+  }
+
+  async function fetchWithAuth(path: string, options: FetchWithAuthOptions = {}) {
+    const { recover = false, ...fetchOptions } = options
+    let headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(fetchOptions.headers as Record<string, string> || {}),
+    }
+
+    if (getTokenFn) {
       try {
-        return await getAccessTokenSilently()
+        const token = await getTokenFn()
+        headers['Authorization'] = `Bearer ${token}`
       } catch (e: any) {
-        // The local refresh token is gone, expired, or has been rotation-revoked.
-        // The Auth0 tenant SSO session cookie typically lives longer than the
-        // refresh token, so try a silent round-trip with prompt=none to recover
-        // transparently. If the SSO session is alive the user comes back
-        // re-authenticated without seeing a sign-in screen. If it's also dead,
-        // Auth0 redirects back with an error and this throw propagates so the
-        // caller can show "sign in again". appState.target preserves the user's
-        // location for a future onRedirectCallback to consume.
         const recoverable = ['login_required', 'consent_required', 'missing_refresh_token', 'invalid_grant']
-        if (recoverable.includes(e?.error)) {
-          const target = window.location.pathname + window.location.search
-          // sessionStorage is the recovery channel for the SSO-also-dead case.
-          // appState.target is what auth0-vue uses on success; sessionStorage is
-          // a backup the auth0 plugin reads in the failure path where auth0-vue
-          // would otherwise redirect to errorPath || '/' and lose the location.
-          if (typeof sessionStorage !== 'undefined') {
-            sessionStorage.setItem('auth0_recovery_target', target)
-          }
-          await loginWithRedirect({
-            authorizationParams: { prompt: 'none' },
-            appState: { target },
-          })
+        if (recover && recoverable.includes(e?.error) && attemptRecovery) {
+          await attemptRecovery()
+          // attemptRecovery navigates the page on success; falling through is
+          // for the case where it returns without navigating (no auth0 session
+          // to recover from), in which case we surface the original error.
         }
         throw e
       }
     }
-  }
-
-  async function fetchWithAuth(path: string, options: RequestInit = {}) {
-    let headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-      ...(options.headers as Record<string, string> || {}),
-    }
-
-    if (getTokenFn) {
-      const token = await getTokenFn()
-      headers['Authorization'] = `Bearer ${token}`
-    }
 
     const response = await fetch(`${baseUrl}/api/v1/${path}`, {
-      ...options,
+      ...fetchOptions,
       headers,
       mode: 'cors',
     })

--- a/evanbecker-client/pages/account.vue
+++ b/evanbecker-client/pages/account.vue
@@ -43,7 +43,7 @@ const profileLoadFailed = ref(false)
 watchEffect(async () => {
   if (!isLoading.value && isAuthenticated.value && !currentUser.value && !profileLoadFailed.value) {
     try {
-      currentUser.value = await fetchWithAuth('user')
+      currentUser.value = await fetchWithAuth('user', { recover: true })
     } catch {
       profileLoadFailed.value = true
     }


### PR DESCRIPTION
## Summary

Critical hotfix. The previous `prompt=none` silent-recovery flow in `fetchWithAuth` ran on every auth failure, including the `loadUser()` call `CommentSection` makes on every article page mount. For logged-out visitors reading a public article, this triggered a redirect to Auth0 and bounced them off the article they were trying to read.

`fetchWithAuth` now takes a `recover?: boolean` option (default `false`). Only the `/account` page-mount profile load opts in. Every other call site — comment loads, comment posts, profile saves — fails quietly the way it used to.

Also added a belt-and-suspenders `isAuthenticated.value` check inside `attemptRecovery`: even if a caller asks for recovery, we skip silently when the user has no Auth0 session at all.

## Test plan

- [ ] Open a public article (e.g. `/articles/why-1196-isnt-agi`) while logged out — page loads, no redirect, comment section shows public comments
- [ ] Open the same article while logged in — page loads normally, comments render, no redirect
- [ ] Visit `/account` while logged in with a fresh session — profile loads
- [ ] Visit `/account` while logged in with a dead refresh token but live SSO — page silently re-auths, profile loads (recovery still works on opt-in)