### PR TITLE
Drop prompt=none recovery, use interactive login on auth failure

### DIFF
--- a/evanbecker-client/composables/useApi.ts
+++ b/evanbecker-client/composables/useApi.ts
@@ -2,16 +2,18 @@ import { useAuth0 } from '@auth0/auth0-vue'
 
 export interface FetchWithAuthOptions extends RequestInit {
   /**
-   * Opt in to automatic silent re-auth when getAccessTokenSilently throws.
+   * Opt in to automatic re-authentication when getAccessTokenSilently throws
+   * an auth error.
    *
    * Defaults to false, which is correct for almost every call site: a public
    * blog page that quietly tries to load the current user (e.g. the comment
    * section) must NOT trigger a redirect when the visitor is logged out, or
    * any visitor reading a public article will be bounced to Auth0 mid-read.
    *
-   * Pass `recover: true` only on call sites where (a) the user is on a page
-   * dedicated to authenticated functionality and (b) silently re-establishing
-   * a session is the right UX. The /account page mount is the canonical case.
+   * Pass `recover: true` only on call sites where the user is on a page
+   * dedicated to authenticated functionality and falling through to the
+   * universal login is the right UX. The /account page mount is the
+   * canonical case.
    */
   recover?: boolean
 }
@@ -24,34 +26,18 @@ export function useApi() {
   // import.meta.client is statically false in the server bundle so this block
   // is entirely eliminated there; on the client it runs in component setup context.
   let getTokenFn: (() => Promise<string>) | null = null
-  let attemptRecovery: (() => Promise<void>) | null = null
+  let triggerLogin: (() => Promise<void>) | null = null
   if (import.meta.client) {
-    const { getAccessTokenSilently, loginWithRedirect, isAuthenticated } = useAuth0()
+    const { getAccessTokenSilently, loginWithRedirect } = useAuth0()
     getTokenFn = getAccessTokenSilently
-    attemptRecovery = async () => {
-      // Belt-and-suspenders: if the user has no Auth0 session at all (never
-      // logged in, or explicitly logged out), there's nothing to recover and
-      // bouncing them through Auth0 would be disruptive. Skip silently.
-      if (!isAuthenticated.value) return
-      // The local refresh token is gone, expired, or rotation-revoked but the
-      // Auth0 tenant SSO session cookie may still be alive. Try a silent
-      // round-trip with prompt=none. On success the user comes back
-      // re-authenticated. On failure Auth0 redirects back with an error and
-      // the auth0 plugin's recovery target watcher restores their location.
-      const target = window.location.pathname + window.location.search
-      if (typeof sessionStorage !== 'undefined') {
-        sessionStorage.setItem('auth0_recovery_target', target)
-      }
-      await loginWithRedirect({
-        authorizationParams: { prompt: 'none' },
-        appState: { target },
-      })
-    }
+    triggerLogin = () => loginWithRedirect({
+      appState: { target: window.location.pathname + window.location.search },
+    })
   }
 
   async function fetchWithAuth(path: string, options: FetchWithAuthOptions = {}) {
     const { recover = false, ...fetchOptions } = options
-    let headers: Record<string, string> = {
+    const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       ...(fetchOptions.headers as Record<string, string> || {}),
     }
@@ -61,12 +47,15 @@ export function useApi() {
         const token = await getTokenFn()
         headers['Authorization'] = `Bearer ${token}`
       } catch (e: any) {
+        // The Auth0 SDK already handled the silent refresh attempt internally
+        // (using the refresh token via getAccessTokenSilently). If it threw an
+        // auth error, the session genuinely cannot be silently re-established.
+        // The canonical Auth0 SPA pattern at this point is to send the user
+        // through the universal login. After they sign in, auth0-vue's
+        // __checkSession reads appState.target and routes them back here.
         const recoverable = ['login_required', 'consent_required', 'missing_refresh_token', 'invalid_grant']
-        if (recover && recoverable.includes(e?.error) && attemptRecovery) {
-          await attemptRecovery()
-          // attemptRecovery navigates the page on success; falling through is
-          // for the case where it returns without navigating (no auth0 session
-          // to recover from), in which case we surface the original error.
+        if (recover && recoverable.includes(e?.error) && triggerLogin) {
+          await triggerLogin()
         }
         throw e
       }

--- a/evanbecker-client/plugins/auth0.client.ts
+++ b/evanbecker-client/plugins/auth0.client.ts
@@ -23,56 +23,27 @@ export default defineNuxtPlugin((nuxtApp) => {
 
     nuxtApp.vueApp.use(auth0)
 
-    // Recovery flow continuation. useApi.fetchWithAuth triggers a prompt=none
-    // redirect when the local refresh token is dead, writing the user's
-    // original location into sessionStorage so we can restore it here on the
-    // post-redirect page load.
-    //
-    // Two branches we have to handle:
-    //   1. Silent recovery succeeded — Auth0 SSO cookie was alive, the user is
-    //      now authenticated. auth0-vue's __checkSession already navigates to
-    //      appState.target on this branch, but we double-check with the router
-    //      in case anything raced.
-    //   2. Silent recovery failed — Auth0 SSO cookie was also dead, Auth0
-    //      redirected back with error=login_required. auth0-vue's __checkSession
-    //      catch path lands the user on errorPath || '/', signed out. The user
-    //      explicitly wants this case to escalate into an interactive
-    //      loginWithRedirect so they can sign back in and return to their page.
+    // Recovery: useApi.fetchWithAuth triggers a prompt=none redirect when the
+    // local refresh token is dead. On success, auth0-vue navigates to the
+    // appState.target. On failure (SSO session also dead), it falls back to
+    // errorPath || '/', which loses the user's place. sessionStorage carries
+    // the intended target across the round-trip so we can restore it here
+    // regardless of which branch auth0-vue takes.
     if (typeof sessionStorage !== 'undefined') {
       const target = sessionStorage.getItem('auth0_recovery_target')
       if (target) {
         sessionStorage.removeItem('auth0_recovery_target')
-        const router = useRouter()
-
-        // Use a one-shot guard so the watcher only acts on the first
-        // isLoading=false transition. Defining it before watchEffect avoids
-        // any self-reference race when the effect fires synchronously.
-        let handled = false
-        watchEffect(() => {
-          if (auth0.isLoading.value) return
-          if (handled) return
-          handled = true
-
-          // Defer one tick past auth0-vue's own __checkSession completion. Its
-          // router.push(errorPath) runs in the catch branch *after* isLoading
-          // flips false, so without this tick we'd race it and our navigation
-          // could be silently overwritten.
-          setTimeout(() => {
-            if (auth0.isAuthenticated.value) {
-              // Silent recovery worked. Make sure we're at the target.
-              const currentPath = window.location.pathname + window.location.search
-              if (currentPath !== target) {
-                router.push(target)
-              }
-              return
+        // Wait for auth0-vue's __checkSession to finish before checking where
+        // we actually landed, otherwise we race its router.push.
+        const stop = watch(auth0.isLoading, (loading: boolean) => {
+          if (!loading) {
+            stop()
+            const currentPath = window.location.pathname + window.location.search
+            if (currentPath !== target) {
+              navigateTo(target)
             }
-
-            // Silent recovery failed. Escalate to interactive login. The user
-            // sees the Auth0 login screen, signs in, and lands back on the
-            // original target via appState resolution in __checkSession.
-            auth0.loginWithRedirect({ appState: { target } })
-          }, 0)
-        })
+          }
+        }, { immediate: true })
       }
     }
   } catch (e) {

--- a/evanbecker-client/plugins/auth0.client.ts
+++ b/evanbecker-client/plugins/auth0.client.ts
@@ -23,27 +23,56 @@ export default defineNuxtPlugin((nuxtApp) => {
 
     nuxtApp.vueApp.use(auth0)
 
-    // Recovery: useApi.fetchWithAuth triggers a prompt=none redirect when the
-    // local refresh token is dead. On success, auth0-vue navigates to the
-    // appState.target. On failure (SSO session also dead), it falls back to
-    // errorPath || '/', which loses the user's place. sessionStorage carries
-    // the intended target across the round-trip so we can restore it here
-    // regardless of which branch auth0-vue takes.
+    // Recovery flow continuation. useApi.fetchWithAuth triggers a prompt=none
+    // redirect when the local refresh token is dead, writing the user's
+    // original location into sessionStorage so we can restore it here on the
+    // post-redirect page load.
+    //
+    // Two branches we have to handle:
+    //   1. Silent recovery succeeded — Auth0 SSO cookie was alive, the user is
+    //      now authenticated. auth0-vue's __checkSession already navigates to
+    //      appState.target on this branch, but we double-check with the router
+    //      in case anything raced.
+    //   2. Silent recovery failed — Auth0 SSO cookie was also dead, Auth0
+    //      redirected back with error=login_required. auth0-vue's __checkSession
+    //      catch path lands the user on errorPath || '/', signed out. The user
+    //      explicitly wants this case to escalate into an interactive
+    //      loginWithRedirect so they can sign back in and return to their page.
     if (typeof sessionStorage !== 'undefined') {
       const target = sessionStorage.getItem('auth0_recovery_target')
       if (target) {
         sessionStorage.removeItem('auth0_recovery_target')
-        // Wait for auth0-vue's __checkSession to finish before checking where
-        // we actually landed, otherwise we race its router.push.
-        const stop = watch(auth0.isLoading, (loading: boolean) => {
-          if (!loading) {
-            stop()
-            const currentPath = window.location.pathname + window.location.search
-            if (currentPath !== target) {
-              navigateTo(target)
+        const router = useRouter()
+
+        // Use a one-shot guard so the watcher only acts on the first
+        // isLoading=false transition. Defining it before watchEffect avoids
+        // any self-reference race when the effect fires synchronously.
+        let handled = false
+        watchEffect(() => {
+          if (auth0.isLoading.value) return
+          if (handled) return
+          handled = true
+
+          // Defer one tick past auth0-vue's own __checkSession completion. Its
+          // router.push(errorPath) runs in the catch branch *after* isLoading
+          // flips false, so without this tick we'd race it and our navigation
+          // could be silently overwritten.
+          setTimeout(() => {
+            if (auth0.isAuthenticated.value) {
+              // Silent recovery worked. Make sure we're at the target.
+              const currentPath = window.location.pathname + window.location.search
+              if (currentPath !== target) {
+                router.push(target)
+              }
+              return
             }
-          }
-        }, { immediate: true })
+
+            // Silent recovery failed. Escalate to interactive login. The user
+            // sees the Auth0 login screen, signs in, and lands back on the
+            // original target via appState resolution in __checkSession.
+            auth0.loginWithRedirect({ appState: { target } })
+          }, 0)
+        })
       }
     }
   } catch (e) {

--- a/evanbecker-client/plugins/auth0.client.ts
+++ b/evanbecker-client/plugins/auth0.client.ts
@@ -22,30 +22,6 @@ export default defineNuxtPlugin((nuxtApp) => {
     })
 
     nuxtApp.vueApp.use(auth0)
-
-    // Recovery: useApi.fetchWithAuth triggers a prompt=none redirect when the
-    // local refresh token is dead. On success, auth0-vue navigates to the
-    // appState.target. On failure (SSO session also dead), it falls back to
-    // errorPath || '/', which loses the user's place. sessionStorage carries
-    // the intended target across the round-trip so we can restore it here
-    // regardless of which branch auth0-vue takes.
-    if (typeof sessionStorage !== 'undefined') {
-      const target = sessionStorage.getItem('auth0_recovery_target')
-      if (target) {
-        sessionStorage.removeItem('auth0_recovery_target')
-        // Wait for auth0-vue's __checkSession to finish before checking where
-        // we actually landed, otherwise we race its router.push.
-        const stop = watch(auth0.isLoading, (loading: boolean) => {
-          if (!loading) {
-            stop()
-            const currentPath = window.location.pathname + window.location.search
-            if (currentPath !== target) {
-              navigateTo(target)
-            }
-          }
-        }, { immediate: true })
-      }
-    }
   } catch (e) {
     console.warn('Auth0: failed to initialize, app will run without authentication.', e)
   }


### PR DESCRIPTION
## Summary

Replaces the prompt=none-based silent re-auth flow with the canonical Auth0 SPA pattern: when getAccessTokenSilently throws an auth error, send the user through the universal login with appState.target set to their current path. auth0-vue's __checkSession routes them back after sign-in.

The prompt=none approach was redundant — getAccessTokenSilently already exercises the refresh token internally. Layering another silent attempt on top via prompt=none caused a cycle: error=login_required came back, the cached ID token kept isAuthenticated.value true, the recovery-target watcher router.pushed to /account, /account re-mounted and called fetchWithAuth, which fired prompt=none again.

## What changed

- composables/useApi.ts — on auth error in fetchWithAuth, calls loginWithRedirect directly (no prompt=none)
- plugins/auth0.client.ts — stripped the recovery-target watcher and all sessionStorage logic; back to plain createAuth0 + vueApp.use

Net change: -55 +20 lines.

## Test plan

- [ ] Sign in normally on /account — profile loads, no behavioral change
- [ ] Force a stale refresh token and visit /account — Auth0 universal login page shows; after sign-in, lands back on /account authenticated, profile loads
- [ ] Browse public pages with a dead refresh token — no forced redirects (recover defaults to false)
- [ ] Header Sign In button still works for normal interactive login