### PR TITLE
Update The Wall publish date to 2026-05-01

### DIFF
--- a/evanbecker-client/content/articles/the-wall.md
+++ b/evanbecker-client/content/articles/the-wall.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Wall'
 description: 'AI engineering keeps running into a boundary that science itself was built to ignore. Where the wall came from, who has hit it before, and what working honestly on the wrong side of it looks like.'
-date: '2026-04-24'
+date: '2026-05-01'
 tags:
   - software
   - ai


### PR DESCRIPTION
## Summary

Single-line frontmatter change to bump the publish date from 2026-04-24 to 2026-05-01, reflecting the actual authoring moment after applying the Shawn-feedback insertions in #48. Piece is being shared out this coming week, so the date should match the version readers will encounter.

## Test plan
- [ ] Confirm date renders correctly on the article page after deploy