### PR TITLE
SEO Phase 1+2: structured data + sitemap polish

### DIFF
--- a/evanbecker-client/app.vue
+++ b/evanbecker-client/app.vue
@@ -28,6 +28,8 @@ useHead({
     ...(isProduction ? [] : [{ name: 'robots', content: 'noindex, nofollow' }]),
   ],
 })
+
+useWebSiteSchema()
 </script>
 
 <template>

--- a/evanbecker-client/composables/useStructuredData.ts
+++ b/evanbecker-client/composables/useStructuredData.ts
@@ -1,0 +1,111 @@
+type ArticleSchemaData = {
+  title: string
+  description?: string
+  date?: string
+  dateModified?: string
+  image?: string
+  tags?: string[]
+  path: string
+}
+
+function siteRoot(): string {
+  const config = useRuntimeConfig()
+  return (config.public.siteUrl as string).replace(/\/$/, '')
+}
+
+function personSchema(siteUrl: string) {
+  return {
+    '@type': 'Person',
+    '@id': `${siteUrl}/#person`,
+    name: 'Evan Becker',
+    url: siteUrl,
+    jobTitle: 'Senior Technical Architect',
+    sameAs: [
+      'https://www.linkedin.com/in/evanbeckerdotnet/',
+      'https://github.com/evanjbecker',
+      'https://gitlab.com/evanbecker',
+    ],
+  }
+}
+
+export function useWebSiteSchema() {
+  const siteUrl = siteRoot()
+
+  const graph = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebSite',
+        '@id': `${siteUrl}/#website`,
+        url: siteUrl,
+        name: 'Evan Becker',
+        description: 'Software architect, writer, and builder of things.',
+        publisher: { '@id': `${siteUrl}/#person` },
+        inLanguage: 'en-US',
+      },
+      personSchema(siteUrl),
+    ],
+  }
+
+  useHead({
+    script: [
+      {
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify(graph),
+        key: 'website-schema',
+      },
+    ],
+  })
+}
+
+export function useArticleSchema(article: ArticleSchemaData) {
+  const siteUrl = siteRoot()
+  const articleUrl = `${siteUrl}${article.path}`
+  const imageUrl = article.image
+    ? `${siteUrl}${article.image}`
+    : `${siteUrl}/og-image.png`
+
+  const articleGraph: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: article.title,
+    description: article.description,
+    image: imageUrl,
+    author: { '@id': `${siteUrl}/#person` },
+    publisher: { '@id': `${siteUrl}/#person` },
+    datePublished: article.date,
+    dateModified: article.dateModified || article.date,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': articleUrl },
+    inLanguage: 'en-US',
+  }
+
+  if (article.tags?.length) {
+    articleGraph.keywords = article.tags.join(', ')
+    articleGraph.articleSection = article.tags[0]
+  }
+
+  const breadcrumbs = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: siteUrl },
+      { '@type': 'ListItem', position: 2, name: 'Articles', item: `${siteUrl}/articles` },
+      { '@type': 'ListItem', position: 3, name: article.title, item: articleUrl },
+    ],
+  }
+
+  useHead({
+    script: [
+      {
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify(articleGraph),
+        key: 'article-schema',
+      },
+      {
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify(breadcrumbs),
+        key: 'article-breadcrumb',
+      },
+    ],
+  })
+}

--- a/evanbecker-client/pages/articles/[...slug].vue
+++ b/evanbecker-client/pages/articles/[...slug].vue
@@ -18,6 +18,7 @@ const articleDescription = article.value.description || ''
 const articleImage = article.value.image
   ? `${config.public.siteUrl.replace(/\/$/, '')}${article.value.image}`
   : `${config.public.siteUrl.replace(/\/$/, '')}/og-image.png`
+const articleModified = article.value.dateModified || article.value.date
 
 useSeoMeta({
   title: articleTitle,
@@ -31,8 +32,19 @@ useSeoMeta({
   twitterDescription: articleDescription,
   twitterImage: articleImage,
   articlePublishedTime: article.value.date,
+  articleModifiedTime: articleModified,
   articleAuthor: ['Evan Becker'],
   articleTag: article.value.tags,
+})
+
+useArticleSchema({
+  title: article.value.title,
+  description: article.value.description,
+  date: article.value.date,
+  dateModified: article.value.dateModified,
+  image: article.value.image,
+  tags: article.value.tags,
+  path: route.path,
 })
 </script>
 

--- a/evanbecker-client/server/api/__sitemap__/urls.ts
+++ b/evanbecker-client/server/api/__sitemap__/urls.ts
@@ -1,15 +1,36 @@
 import { serverQueryContent } from '#content/server'
 import { defineSitemapEventHandler } from '#imports'
 
+const STATIC_PAGES: Array<{ loc: string; priority: number; changefreq: 'daily' | 'weekly' | 'monthly' | 'yearly' }> = [
+  { loc: '/', priority: 1.0, changefreq: 'weekly' },
+  { loc: '/articles', priority: 0.9, changefreq: 'weekly' },
+  { loc: '/about-me', priority: 0.7, changefreq: 'yearly' },
+  { loc: '/contact', priority: 0.5, changefreq: 'yearly' },
+  { loc: '/privacy-policy', priority: 0.3, changefreq: 'yearly' },
+]
+
 export default defineSitemapEventHandler(async (event) => {
   const articles = await serverQueryContent(event, 'articles')
     .where({ _draft: { $ne: true } })
     .find()
 
-  return articles.map((article) => ({
+  const articleUrls = articles.map((article) => ({
     loc: article._path,
-    lastmod: article.date,
-    changefreq: 'monthly',
+    lastmod: article.dateModified || article.date,
+    changefreq: 'monthly' as const,
     priority: 0.8,
   }))
+
+  // Use the freshest article date as a proxy for site freshness on static pages.
+  const latest = articles.reduce(
+    (max, a) => {
+      const candidate = (a.dateModified as string) || (a.date as string) || ''
+      return candidate > max ? candidate : max
+    },
+    '2026-01-01',
+  )
+
+  const staticUrls = STATIC_PAGES.map((p) => ({ ...p, lastmod: latest }))
+
+  return [...staticUrls, ...articleUrls]
 })


### PR DESCRIPTION
## Summary

Adds JSON-LD structured data and tightens sitemap signals. Builds on Phase 0 (#50, indexing fix). After Phase 0 deploys, this gives Google explicit machine-readable identity for the site, the author, and each article.

## What's added

**Structured data** (new ``composables/useStructuredData.ts``):
- ``useWebSiteSchema()`` emits a WebSite + Person ``@graph`` via ``app.vue`` (every page)
- ``useArticleSchema(article)`` emits Article + BreadcrumbList from ``pages/articles/[...slug].vue``
- Article schema references the Person by ``@id`` so author identity ties together across the graph
- ``sameAs`` on Person points to LinkedIn / GitHub / GitLab — feeds knowledge-panel signals
- BreadcrumbList earns the breadcrumb display in SERPs (Home › Articles › Title)

**Sitemap polish** (``server/api/__sitemap__/urls.ts``):
- Static pages explicitly added with ``priority``, ``changefreq``, and ``lastmod``. ``lastmod`` tracks the freshest article date as a proxy for site freshness.
- Articles now consume optional ``dateModified`` frontmatter, falling back to ``date``.

**Frontmatter support**:
- Articles can now declare ``dateModified`` to signal substantive updates without changing original publish date. Already wired into og:article:modified_time and Article schema.

## Verification (already done locally on dev server)

- 3 ``application/ld+json`` blocks render on article pages: WebSite/Person graph, Article, BreadcrumbList
- 2 ``application/ld+json`` blocks render on home page: WebSite/Person graph
- ``sitemap.xml`` includes all 5 static pages with lastmod, plus all 5 articles
- No server errors after edits
- Schemas pretty-printed and visually validated; ``@id`` references line up across graph

After deploy, recommended to validate with [Google Rich Results Test](https://search.google.com/test/rich-results) on a published article URL.

## Test plan
- [ ] Validate Article schema on a deployed article via Rich Results Test
- [ ] Validate WebSite schema on home page
- [ ] Confirm sitemap.xml has lastmod for all entries
- [ ] Resubmit sitemap in GSC after Phase 0 lands and confirm no JSON-LD errors