### PR TITLE
SEO Phase 4: Related articles section

### DIFF
--- a/evanbecker-client/components/RelatedArticles.vue
+++ b/evanbecker-client/components/RelatedArticles.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+const props = defineProps<{
+  currentPath: string
+  currentTags?: string[]
+}>()
+
+const { data: candidates } = await useAsyncData(
+  `related-${props.currentPath}`,
+  () => queryContent('articles')
+    .where({ _draft: { $ne: true } })
+    .sort({ date: -1 })
+    .find(),
+)
+
+const related = computed(() => {
+  const all = candidates.value || []
+  const tags = new Set(props.currentTags || [])
+
+  const scored = all
+    .filter((a) => a._path !== props.currentPath)
+    .map((a) => {
+      const overlap = (a.tags || []).filter((t: string) => tags.has(t)).length
+      return { article: a, overlap }
+    })
+
+  // If we have tags, prefer overlap-then-date. Otherwise just take recent.
+  if (tags.size > 0) {
+    scored.sort((a, b) => {
+      if (b.overlap !== a.overlap) return b.overlap - a.overlap
+      return (b.article.date || '').localeCompare(a.article.date || '')
+    })
+  }
+
+  return scored.slice(0, 3).map((s) => s.article)
+})
+</script>
+
+<template>
+  <section v-if="related.length > 0" aria-labelledby="related-heading">
+    <h2 id="related-heading" class="font-serif text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">
+      Related articles
+    </h2>
+    <div class="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <article
+        v-for="article in related"
+        :key="article._path"
+        class="group rounded-2xl border border-slate-200 p-5 transition hover:border-[#2D95FC] dark:border-slate-700 dark:hover:border-[#2D95FC]"
+      >
+        <NuxtLink :to="article._path" class="block">
+          <time
+            v-if="article.date"
+            :datetime="article.date"
+            class="text-xs font-medium text-slate-400 dark:text-slate-500"
+          >
+            {{ formatArticleDate(article.date) }}
+          </time>
+          <h3 class="mt-2 font-serif text-lg font-semibold text-slate-800 transition group-hover:text-[#0C65E5] dark:text-slate-100 dark:group-hover:text-[#2D95FC]">
+            {{ article.title }}
+          </h3>
+          <p v-if="article.description" class="mt-2 line-clamp-3 text-sm text-slate-500 dark:text-slate-400">
+            {{ article.description }}
+          </p>
+          <div v-if="article.tags?.length" class="mt-3 flex flex-wrap gap-1.5">
+            <span
+              v-for="tag in article.tags.slice(0, 3)"
+              :key="tag"
+              class="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-[#0C65E5] dark:bg-[#0C65E5]/10 dark:text-[#41A5F7]"
+            >
+              {{ tag }}
+            </span>
+          </div>
+        </NuxtLink>
+      </article>
+    </div>
+  </section>
+</template>

--- a/evanbecker-client/pages/articles/[...slug].vue
+++ b/evanbecker-client/pages/articles/[...slug].vue
@@ -92,8 +92,16 @@ useArticleSchema({
       />
     </div>
 
+    <!-- Related articles -->
+    <div class="mt-16 border-t border-slate-200 pt-12 dark:border-slate-700">
+      <RelatedArticles
+        :current-path="route.path"
+        :current-tags="article.tags"
+      />
+    </div>
+
     <!-- Comments -->
-    <div class="mt-16 border-t border-slate-200 dark:border-slate-700">
+    <div class="mt-16 border-t border-slate-200 pt-12 dark:border-slate-700">
       <ClientOnly>
         <CommentSection />
       </ClientOnly>


### PR DESCRIPTION
## Summary

Adds a Related Articles section to article pages for internal linking and improved crawl depth.

## What's added

**Component**: ``components/RelatedArticles.vue``
- Queries all non-draft articles, excludes the current one, computes tag-overlap score per article, sorts by overlap-then-date-desc, returns top 3.
- Falls back to most recent articles when no tags overlap.
- Visually consistent with the articles index card style: date, title, description, tags, hover state.
- Accessible: ``aria-labelledby`` links section to its h2.

**Wired into ``pages/articles/[...slug].vue``** above the comments section.

## Why this matters for SEO

- **Internal linking depth**: every article now links to 3 others. Google ranks pages partly by internal link signals.
- **Dwell time**: gives readers a next thing to click without leaving the site, which improves engagement metrics Google watches.
- **Crawl efficiency**: makes the article graph more interconnected, so Googlebot reaches every article in fewer hops.

## Verification (local)

- 3 related articles render on ``/articles/the-wall``: ``Why #1196 Isn't AGI``, ``Math Pretending to Be Architecture``, ``Migrating from Next.js to Nuxt 3`` — correctly prioritizing tag overlap.
- Responsive grid: 1 col mobile, 2 cols tablet (sm: 640px+), 3 cols desktop (lg: 1024px+).
- Dark mode styled correctly.

## Test plan
- [ ] Visual check on prod after deploy
- [ ] Verify related articles update appropriately when viewing different articles