### PR TITLE
SEO Phase 5: featured articles + byline + reading time

### DIFF
--- a/evanbecker-client/components/RelatedArticles.vue
+++ b/evanbecker-client/components/RelatedArticles.vue
@@ -47,13 +47,13 @@ const related = computed(() => {
         class="group rounded-2xl border border-slate-200 p-5 transition hover:border-[#2D95FC] dark:border-slate-700 dark:hover:border-[#2D95FC]"
       >
         <NuxtLink :to="article._path" class="block">
-          <time
-            v-if="article.date"
-            :datetime="article.date"
-            class="text-xs font-medium text-slate-400 dark:text-slate-500"
-          >
-            {{ formatArticleDate(article.date) }}
-          </time>
+          <div class="flex flex-wrap items-center gap-x-2 text-xs font-medium text-slate-400 dark:text-slate-500">
+            <time v-if="article.date" :datetime="article.date">
+              {{ formatArticleDate(article.date) }}
+            </time>
+            <span aria-hidden="true">·</span>
+            <span>{{ articleReadingTime(articleWordCount(article)) }} min read</span>
+          </div>
           <h3 class="mt-2 font-serif text-lg font-semibold text-slate-800 transition group-hover:text-[#0C65E5] dark:text-slate-100 dark:group-hover:text-[#2D95FC]">
             {{ article.title }}
           </h3>

--- a/evanbecker-client/composables/useStructuredData.ts
+++ b/evanbecker-client/composables/useStructuredData.ts
@@ -6,6 +6,7 @@ type ArticleSchemaData = {
   image?: string
   tags?: string[]
   path: string
+  wordCount?: number
 }
 
 function siteRoot(): string {
@@ -82,6 +83,10 @@ export function useArticleSchema(article: ArticleSchemaData) {
   if (article.tags?.length) {
     articleGraph.keywords = article.tags.join(', ')
     articleGraph.articleSection = article.tags[0]
+  }
+
+  if (article.wordCount && article.wordCount > 0) {
+    articleGraph.wordCount = article.wordCount
   }
 
   const breadcrumbs = {

--- a/evanbecker-client/content/articles/the-wall.md
+++ b/evanbecker-client/content/articles/the-wall.md
@@ -2,6 +2,7 @@
 title: 'The Wall'
 description: 'AI engineering keeps running into a boundary that science itself was built to ignore. Where the wall came from, who has hit it before, and what working honestly on the wrong side of it looks like.'
 date: '2026-05-01'
+featured: true
 tags:
   - software
   - ai

--- a/evanbecker-client/pages/articles/[...slug].vue
+++ b/evanbecker-client/pages/articles/[...slug].vue
@@ -19,6 +19,8 @@ const articleImage = article.value.image
   ? `${config.public.siteUrl.replace(/\/$/, '')}${article.value.image}`
   : `${config.public.siteUrl.replace(/\/$/, '')}/og-image.png`
 const articleModified = article.value.dateModified || article.value.date
+const wordCount = articleWordCount(article.value)
+const readingMinutes = articleReadingTime(wordCount)
 
 useSeoMeta({
   title: articleTitle,
@@ -45,6 +47,7 @@ useArticleSchema({
   image: article.value.image,
   tags: article.value.tags,
   path: route.path,
+  wordCount,
 })
 </script>
 
@@ -63,13 +66,15 @@ useArticleSchema({
 
     <!-- Header -->
     <header>
-      <time
-        v-if="article.date"
-        :datetime="article.date"
-        class="text-sm font-medium text-slate-400 dark:text-slate-500"
-      >
-        {{ formatArticleDate(article.date) }}
-      </time>
+      <div class="flex flex-wrap items-center gap-x-2 text-sm font-medium text-slate-400 dark:text-slate-500">
+        <time v-if="article.date" :datetime="article.date">
+          {{ formatArticleDate(article.date) }}
+        </time>
+        <span aria-hidden="true">·</span>
+        <span>by Evan Becker</span>
+        <span aria-hidden="true">·</span>
+        <span>{{ readingMinutes }} min read</span>
+      </div>
       <h1 class="mt-2 font-serif text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl dark:text-slate-50">
         {{ article.title }}
       </h1>

--- a/evanbecker-client/pages/articles/index.vue
+++ b/evanbecker-client/pages/articles/index.vue
@@ -7,6 +7,24 @@ useSeoMeta({
   twitterTitle: 'Articles - Evan Becker',
   twitterDescription: 'All of my long-form thoughts on programming, leadership, product design, and more.',
 })
+
+const { data: articles } = await useAsyncData(
+  'articles-index',
+  () => queryContent('articles')
+    .where({ _draft: { $ne: true } })
+    .sort({ date: -1 })
+    .find(),
+)
+
+const featured = computed(() => (articles.value || []).find((a) => a.featured))
+const timeline = computed(() => {
+  const all = articles.value || []
+  return featured.value ? all.filter((a) => a._path !== featured.value!._path) : all
+})
+
+function readingFor(article: any): number {
+  return articleReadingTime(articleWordCount(article))
+}
 </script>
 
 <template>
@@ -18,51 +36,90 @@ useSeoMeta({
       All of my long-form thoughts captured as I attempt to understand the universe, collected in chronological order and organized by subject matter.
     </p>
 
-    <ContentList path="/articles" :query="{ sort: [{ date: -1 }] }">
-      <template #default="{ list }">
-      <div class="mt-16 space-y-12 border-l border-slate-200 pl-6 dark:border-slate-700">
-        <article v-for="article in list" :key="article._path" class="relative">
-          <!-- Timeline dot -->
-          <div class="absolute -left-[calc(1.5rem+5px)] top-1 h-2.5 w-2.5 rounded-full border-2 border-[#2D95FC] bg-slate-50 dark:bg-[#0B1120]" />
+    <!-- Featured -->
+    <section v-if="featured" aria-labelledby="featured-heading" class="mt-12">
+      <h2 id="featured-heading" class="sr-only">Featured article</h2>
+      <article class="relative overflow-hidden rounded-2xl border border-slate-200 bg-gradient-to-br from-blue-50/25 to-transparent p-8 transition hover:border-[#2D95FC] dark:border-slate-700 dark:from-[#0C65E5]/5 dark:to-transparent dark:hover:border-[#2D95FC]">
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-medium">
+          <span class="inline-flex items-center gap-1 rounded-full bg-[#0C65E5] px-2.5 py-0.5 text-white">
+            <svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.286 3.957a1 1 0 0 0 .95.69h4.162c.969 0 1.371 1.24.588 1.81l-3.366 2.446a1 1 0 0 0-.364 1.118l1.286 3.957c.3.921-.755 1.688-1.54 1.118l-3.366-2.446a1 1 0 0 0-1.176 0L5.485 17.93c-.785.57-1.84-.197-1.54-1.118l1.286-3.957a1 1 0 0 0-.364-1.118L1.502 9.291c-.783-.57-.38-1.81.588-1.81h4.162a1 1 0 0 0 .95-.69l1.286-3.957Z" /></svg>
+            Featured
+          </span>
+          <time v-if="featured.date" :datetime="featured.date" class="text-slate-500 dark:text-slate-400">
+            {{ formatArticleDate(featured.date) }}
+          </time>
+          <span class="text-slate-400 dark:text-slate-500" aria-hidden="true">·</span>
+          <span class="text-slate-500 dark:text-slate-400">{{ readingFor(featured) }} min read</span>
+        </div>
 
-          <time
-            v-if="article.date"
-            :datetime="article.date"
-            class="text-sm font-medium text-slate-400 dark:text-slate-500"
+        <h3 class="mt-3 font-serif text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl dark:text-slate-50">
+          <NuxtLink :to="featured._path" class="transition hover:text-[#0C65E5] dark:hover:text-[#2D95FC]">
+            {{ featured.title }}
+          </NuxtLink>
+        </h3>
+
+        <p v-if="featured.description" class="mt-4 text-base text-slate-600 dark:text-slate-300">
+          {{ featured.description }}
+        </p>
+
+        <div v-if="featured.tags" class="mt-5 flex flex-wrap gap-2">
+          <span
+            v-for="tag in featured.tags"
+            :key="tag"
+            class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-[#0C65E5] dark:bg-[#0C65E5]/10 dark:text-[#41A5F7]"
           >
+            <span class="h-1 w-1 rounded-full bg-[#2D95FC]" />
+            {{ tag }}
+          </span>
+        </div>
+
+        <NuxtLink :to="featured._path" class="mt-6 inline-block text-sm font-medium text-[#0C65E5] dark:text-[#2D95FC]">
+          Read article &rarr;
+        </NuxtLink>
+      </article>
+    </section>
+
+    <!-- Timeline -->
+    <div class="mt-16 space-y-12 border-l border-slate-200 pl-6 dark:border-slate-700">
+      <article v-for="article in timeline" :key="article._path" class="relative">
+        <div class="absolute -left-[calc(1.5rem+5px)] top-1 h-2.5 w-2.5 rounded-full border-2 border-[#2D95FC] bg-slate-50 dark:bg-[#0B1120]" />
+
+        <div class="flex flex-wrap items-center gap-x-2 text-sm font-medium text-slate-400 dark:text-slate-500">
+          <time v-if="article.date" :datetime="article.date">
             {{ formatArticleDate(article.date) }}
           </time>
+          <span aria-hidden="true">·</span>
+          <span>{{ readingFor(article) }} min read</span>
+        </div>
 
-          <h2 class="mt-2 text-xl font-semibold text-slate-800 dark:text-slate-100">
-            <NuxtLink :to="article._path" class="transition hover:text-[#0C65E5] dark:hover:text-[#2D95FC]">
-              {{ article.title }}
-            </NuxtLink>
-          </h2>
-
-          <p v-if="article.description" class="mt-2 text-slate-500 dark:text-slate-400">
-            {{ article.description }}
-          </p>
-
-          <div v-if="article.tags" class="mt-3 flex flex-wrap gap-2">
-            <span
-              v-for="tag in article.tags"
-              :key="tag"
-              class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-[#0C65E5] dark:bg-[#0C65E5]/10 dark:text-[#41A5F7]"
-            >
-              <span class="h-1 w-1 rounded-full bg-[#2D95FC]" />
-              {{ tag }}
-            </span>
-          </div>
-
-          <NuxtLink :to="article._path" class="mt-3 inline-block text-sm font-medium text-[#0C65E5] dark:text-[#2D95FC]">
-            Read article &rarr;
+        <h2 class="mt-2 text-xl font-semibold text-slate-800 dark:text-slate-100">
+          <NuxtLink :to="article._path" class="transition hover:text-[#0C65E5] dark:hover:text-[#2D95FC]">
+            {{ article.title }}
           </NuxtLink>
-        </article>
-      </div>
-      </template>
-      <template #not-found>
-        <p class="mt-16 text-slate-500 dark:text-slate-400">No articles yet.</p>
-      </template>
-    </ContentList>
+        </h2>
+
+        <p v-if="article.description" class="mt-2 text-slate-500 dark:text-slate-400">
+          {{ article.description }}
+        </p>
+
+        <div v-if="article.tags" class="mt-3 flex flex-wrap gap-2">
+          <span
+            v-for="tag in article.tags"
+            :key="tag"
+            class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-[#0C65E5] dark:bg-[#0C65E5]/10 dark:text-[#41A5F7]"
+          >
+            <span class="h-1 w-1 rounded-full bg-[#2D95FC]" />
+            {{ tag }}
+          </span>
+        </div>
+
+        <NuxtLink :to="article._path" class="mt-3 inline-block text-sm font-medium text-[#0C65E5] dark:text-[#2D95FC]">
+          Read article &rarr;
+        </NuxtLink>
+      </article>
+      <p v-if="!featured && timeline.length === 0" class="mt-16 text-slate-500 dark:text-slate-400">
+        No articles yet.
+      </p>
+    </div>
   </div>
 </template>

--- a/evanbecker-client/pages/index.vue
+++ b/evanbecker-client/pages/index.vue
@@ -8,10 +8,21 @@ useSeoMeta({
   twitterDescription: 'I design scalable systems for energy, manufacturing, and chemicals — and write about software architecture, game design, and physics.',
 })
 
-const { data: articles } = await useAsyncData('article-count', () =>
-  queryContent('articles').only(['_path']).find()
+const { data: articles } = await useAsyncData('home-articles', () =>
+  queryContent('articles').where({ _draft: { $ne: true } }).sort({ date: -1 }).find()
 )
 const articleCount = computed(() => articles.value?.length ?? 0)
+
+const featured = computed(() => (articles.value || []).find((a) => a.featured))
+const recent = computed(() => {
+  const all = articles.value || []
+  const filtered = featured.value ? all.filter((a) => a._path !== featured.value!._path) : all
+  return filtered.slice(0, 3)
+})
+
+function readingFor(article: any): number {
+  return articleReadingTime(articleWordCount(article))
+}
 </script>
 
 <template>
@@ -89,32 +100,74 @@ const articleCount = computed(() => articles.value?.length ?? 0)
       </div>
     </section>
 
-    <!-- Recent Articles Preview -->
+    <!-- Featured + Recent -->
     <section class="mx-auto max-w-7xl px-6 py-24 lg:px-8">
-      <div class="flex items-center justify-between">
-        <h2 class="font-serif text-2xl font-semibold text-slate-900 dark:text-slate-100">
-          Recent Writing
-        </h2>
-        <NuxtLink to="/articles" class="text-sm font-medium text-[#0C65E5] transition hover:text-[#2D95FC] dark:text-[#2D95FC] dark:hover:text-[#41A5F7]">
-          View all &rarr;
-        </NuxtLink>
-      </div>
+      <!-- Featured -->
+      <article
+        v-if="featured"
+        class="group relative overflow-hidden rounded-2xl border border-slate-200 bg-gradient-to-br from-blue-50/25 to-transparent p-8 transition hover:border-[#2D95FC] dark:border-slate-700 dark:from-[#0C65E5]/5 dark:to-transparent dark:hover:border-[#2D95FC]"
+      >
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-medium">
+          <span class="inline-flex items-center gap-1 rounded-full bg-[#0C65E5] px-2.5 py-0.5 text-white">
+            <svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.286 3.957a1 1 0 0 0 .95.69h4.162c.969 0 1.371 1.24.588 1.81l-3.366 2.446a1 1 0 0 0-.364 1.118l1.286 3.957c.3.921-.755 1.688-1.54 1.118l-3.366-2.446a1 1 0 0 0-1.176 0L5.485 17.93c-.785.57-1.84-.197-1.54-1.118l1.286-3.957a1 1 0 0 0-.364-1.118L1.502 9.291c-.783-.57-.38-1.81.588-1.81h4.162a1 1 0 0 0 .95-.69l1.286-3.957Z" /></svg>
+            Featured
+          </span>
+          <time v-if="featured.date" :datetime="featured.date" class="text-slate-500 dark:text-slate-400">
+            {{ formatArticleDate(featured.date) }}
+          </time>
+          <span class="text-slate-400 dark:text-slate-500" aria-hidden="true">·</span>
+          <span class="text-slate-500 dark:text-slate-400">{{ readingFor(featured) }} min read</span>
+        </div>
 
-      <ContentList path="/articles" :query="{ limit: 3, sort: [{ date: -1 }] }">
-        <template #default="{ list }">
-        <div class="mt-8 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        <h2 class="mt-3 font-serif text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl dark:text-slate-50">
+          <NuxtLink :to="featured._path" class="transition group-hover:text-[#0C65E5] dark:group-hover:text-[#2D95FC]">
+            {{ featured.title }}
+          </NuxtLink>
+        </h2>
+
+        <p v-if="featured.description" class="mt-4 max-w-3xl text-base text-slate-600 dark:text-slate-300">
+          {{ featured.description }}
+        </p>
+
+        <div v-if="featured.tags" class="mt-5 flex flex-wrap gap-2">
+          <span
+            v-for="tag in featured.tags"
+            :key="tag"
+            class="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-[#0C65E5] dark:bg-[#0C65E5]/10 dark:text-[#41A5F7]"
+          >
+            {{ tag }}
+          </span>
+        </div>
+
+        <NuxtLink :to="featured._path" class="mt-6 inline-block text-sm font-medium text-[#0C65E5] dark:text-[#2D95FC]">
+          Read article &rarr;
+        </NuxtLink>
+      </article>
+
+      <!-- Recent -->
+      <div :class="featured ? 'mt-16' : ''">
+        <div class="flex items-center justify-between">
+          <h2 class="font-serif text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            Recent Writing
+          </h2>
+          <NuxtLink to="/articles" class="text-sm font-medium text-[#0C65E5] transition hover:text-[#2D95FC] dark:text-[#2D95FC] dark:hover:text-[#41A5F7]">
+            View all &rarr;
+          </NuxtLink>
+        </div>
+
+        <div v-if="recent.length > 0" class="mt-8 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
           <article
-            v-for="article in list"
+            v-for="article in recent"
             :key="article._path"
             class="group rounded-2xl border border-slate-200 bg-white p-6 transition hover:border-[#2D95FC]/40 hover:shadow-md dark:border-slate-800 dark:bg-[#1E293B] dark:hover:border-[#2D95FC]/40"
           >
-            <time
-              v-if="article.date"
-              :datetime="article.date"
-              class="text-xs font-medium text-slate-500 dark:text-slate-500"
-            >
-              {{ formatArticleDate(article.date) }}
-            </time>
+            <div class="flex flex-wrap items-center gap-x-2 text-xs font-medium text-slate-500 dark:text-slate-500">
+              <time v-if="article.date" :datetime="article.date">
+                {{ formatArticleDate(article.date) }}
+              </time>
+              <span aria-hidden="true">·</span>
+              <span>{{ readingFor(article) }} min read</span>
+            </div>
             <h3 class="mt-2 text-lg font-semibold text-slate-800 group-hover:text-[#0C65E5] dark:text-slate-100 dark:group-hover:text-[#2D95FC]">
               <NuxtLink :to="article._path">{{ article.title }}</NuxtLink>
             </h3>
@@ -132,11 +185,8 @@ const articleCount = computed(() => articles.value?.length ?? 0)
             </div>
           </article>
         </div>
-        </template>
-        <template #not-found>
-          <p class="mt-8 text-sm text-slate-500 dark:text-slate-400">No articles yet.</p>
-        </template>
-      </ContentList>
+        <p v-else class="mt-8 text-sm text-slate-500 dark:text-slate-400">No articles yet.</p>
+      </div>
     </section>
   </div>
 </template>

--- a/evanbecker-client/utils/articleStats.ts
+++ b/evanbecker-client/utils/articleStats.ts
@@ -1,0 +1,25 @@
+// Average adult reading speed for non-technical prose. The Wall comes out
+// to roughly 23 minutes at 225 wpm, which matches a careful read.
+const WORDS_PER_MINUTE = 225
+
+function flattenText(node: unknown): string {
+  if (!node) return ''
+  if (typeof node === 'string') return node
+  if (Array.isArray(node)) return node.map(flattenText).join(' ')
+  if (typeof node === 'object') {
+    const n = node as { type?: string; value?: string; children?: unknown }
+    if (n.type === 'text' && typeof n.value === 'string') return n.value
+    if (n.children) return flattenText(n.children)
+  }
+  return ''
+}
+
+export function articleWordCount(article: unknown): number {
+  const body = (article as { body?: unknown })?.body
+  const text = flattenText(body)
+  return text.split(/\s+/).filter(Boolean).length
+}
+
+export function articleReadingTime(wordCount: number): number {
+  return Math.max(1, Math.round(wordCount / WORDS_PER_MINUTE))
+}


### PR DESCRIPTION
## Summary

Surfaces articles better across the site. Targeted to develop so we can verify on test.evanbecker.net before merging to main.

## What's added

**Frontmatter**
- Optional ``featured: true`` flag. The Wall is flagged as the inaugural featured article.

**Reading time + word count**
- New utility: ``utils/articleStats.ts`` walks the article body AST and computes a word count, with a simple ``readingTime`` derived at 225 wpm.
- Article header: shows ``date · by Evan Becker · X min read`` as a single subtle metadata line above the title.
- Cards across home, articles index, and Related Articles all show reading time alongside date.
- Word count is also wired into the Article JSON-LD schema (``wordCount`` field).

**Featured treatment**
- Articles index: featured article gets a hero card above the timeline. Subtle gradient tint, "Featured" pill, larger typography. Timeline below excludes the featured to avoid duplication.
- Home page: same featured hero card lands above the existing Recent Writing grid. Recent Writing also drops the featured to avoid showing the same piece twice.
- Gradient is intentionally subtle (light: ``from-blue-50/25``, dark: ``from-[#0C65E5]/5``) — visible enough to mark the card without dominating.

## Why this matters

- Featured slot protects strongest essays from being buried by newer posts (The Wall and Math Pretending to Be Architecture were sliding off home page real estate as new pieces published).
- Visible byline gives Google E-E-A-T signal beyond the JSON-LD author field, which matters when first-time readers land from search.
- Reading time helps readers self-select — particularly important for a 25-min essay vs. a 9-min one.

## Test plan
- [ ] Visit test.evanbecker.net, verify featured hero shows on home page above Recent Writing
- [ ] Verify featured hero shows on /articles above timeline
- [ ] Verify The Wall is not duplicated (featured + recent shows it once)
- [ ] Verify byline + reading time render on article header
- [ ] Verify Related Articles cards now show reading time
- [ ] Confirm gradient tint is subtle, not dominant
- [ ] Validate Article schema includes wordCount via Rich Results Test