### PR TITLE
Bump reading-time estimate to 150 wpm

### DIFF
--- a/evanbecker-client/utils/articleStats.ts
+++ b/evanbecker-client/utils/articleStats.ts
@@ -1,6 +1,6 @@
-// Average adult reading speed for non-technical prose. The Wall comes out
-// to roughly 23 minutes at 225 wpm, which matches a careful read.
-const WORDS_PER_MINUTE = 225
+// 150 wpm matches a careful read of dense longform — closer to actual
+// comprehension speed than the casual-prose default of 225.
+const WORDS_PER_MINUTE = 150
 
 function flattenText(node: unknown): string {
   if (!node) return ''


### PR DESCRIPTION
## Summary

Tweak the reading-time constant in ``utils/articleStats.ts`` from 225 wpm to 150 wpm. ~50% boost to every displayed estimate.

The 225 number reflects casual prose; the articles on this site are dense longform that reads more slowly. New numbers feel more honest:

- The Wall: 25 → 37 min
- Why #1196 Isn't AGI: 9 → 14 min
- Math Pretending to Be Architecture: 10 → 15 min
- Migrating from Next.js to Nuxt 3: similar bump

## Test plan
- [ ] Verify times on test.evanbecker.net look right (article header + cards)