### PR TITLE
Rewrite home page bio for accuracy

### DIFF
--- a/evanbecker-client/pages/index.vue
+++ b/evanbecker-client/pages/index.vue
@@ -41,10 +41,14 @@ function readingFor(article: any): number {
             Software Architect, Writer, <span class="text-[#0C65E5] dark:text-[#2D95FC]">&amp;</span> Builder
           </p>
           <p class="mt-6 text-lg leading-relaxed text-slate-600 dark:text-slate-400">
-            I design scalable systems and solve complex problems for enterprises across
-            energy, manufacturing, and chemicals. I write about
-            software architecture, game design, physics, and whatever else I'm exploring.
-            This site is self-hosted on a
+            I'm a Senior Technical Architect at
+            <a href="https://www.nvisia.com/" class="link-underline">nvisia</a>,
+            consulting on software architecture across industries. Before consulting,
+            I built coordinate-measuring software at
+            <a href="https://www.mitutoyo.com/" class="link-underline">Mitutoyo</a>
+            for aerospace-grade tolerances. Outside of client work I'm building Zeroset,
+            a browser-native SDF modeling tool, and writing about AI agents,
+            consciousness, and where the math runs out. This site is self-hosted on a
             <a href="https://www.proxmox.com/" class="link-underline">Proxmox</a> homelab.
           </p>
 


### PR DESCRIPTION
## Summary

Replaces the home page hero bio with a more accurate version. Targeted to develop for review on test.evanbecker.net.

**Changes:**
- Senior Technical Architect at nvisia (actual title, real employer link)
- Consulting across industries (was: limited to energy/manufacturing/chemicals, which overstated client breadth)
- Mitutoyo aerospace-grade tolerances (surfaces actual past work, with link)
- Zeroset side build mentioned (browser-native SDF modeling tool)
- Writing topics updated to current focus (AI agents, consciousness, philosophy of mind), dropped game design which isn't an active thread
- Proxmox link kept

Zeroset is mentioned but not linked yet since zeroset.app isn't fully live. Easy follow-up to add the link once it's up.

## Test plan
- [ ] Verify the hero paragraph reads cleanly on test.evanbecker.net
- [ ] Confirm nvisia, Mitutoyo, and Proxmox links work